### PR TITLE
Added support for Microsoft USB Keyboards

### DIFF
--- a/kext/DoubleCommand.cpp
+++ b/kext/DoubleCommand.cpp
@@ -322,6 +322,10 @@ int hijack_keyboard(IOHIKeyboard * kbd)
 	{
 		hijack = true;
 	}
+	else if (strcmp(name, "MicrosoftKeyboardUSB") == 0)
+	{
+		hijack = true;
+	}
 	else
 	{
 		IOLog("DoubleCommand does not support %s\n", name);


### PR DESCRIPTION
Hi,
I added support for Microsoft USB Keyboards.
I only tested it for the Microsoft Natural Ergonomics 4000 v1.0 and it works flawlessly.

I'd appreciate if you could incorporate the few bits into the main repository.

Cheers,
  Gerolf
